### PR TITLE
Update composer.json to use latest Robo helpers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,11 +5,11 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "digipolisgent/robo-digipolis-helpers": "^4.0",
+        "digipolisgent/robo-digipolis-helpers": "^5.0",
         "vlucas/phpdotenv": "^4 || ^5"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.5.20"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
In an effort to upgrade Laravel in opening hours, we stumbled upon a dependency on `digipolis-robo-helpers` (4.x) which in turn depended on `roave/better-reflection`, which depends on PHP 8.0 - 8.2, not 8.3, making it a drag to upgrade.

We are now using the 5.0.. version of Robo helpers and at the same time we locked down the PHPUnit version, in line with
`robo-digipolis-drupal`.